### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-KEYWORD1    VEML6070
+KEYWORD1	VEML6070
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-KEYWORD2    init
-KEYWORD2    read_step
-KEYWORD2    set_interrupt
-KEYWORD2    set_cmd_reg
-KEYWORD2    clear_ack
-KEYWORD2    convert_to_risk_level
+KEYWORD2	init
+KEYWORD2	read_step
+KEYWORD2	set_interrupt
+KEYWORD2	set_cmd_reg
+KEYWORD2	clear_ack
+KEYWORD2	convert_to_risk_level
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords