### PR TITLE
Fix filename case in #include directive

### DIFF
--- a/Seeed_VEML6070.h
+++ b/Seeed_VEML6070.h
@@ -1,7 +1,7 @@
 #ifndef _SEEED_VE_H
 #define _SEEED_VE_H
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "Wire.h"
 
 


### PR DESCRIPTION
Incorrect capitalization of Arduino.h in #include directive causes compilation to fail on filename case-sensitive operating systems like Linux.